### PR TITLE
Maven-stapler-plugin was upgraded to 1.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>maven-stapler-plugin</artifactId>
-      <version>1.15</version>
+      <version>1.16</version>
       <!-- make sure to exclude servlet so that the one in Jetty (which has different groupId) will win -->
       <exclusions>
         <exclusion>

--- a/src/main/java/org/jvnet/hudson/maven/plugins/hpi/AnnotationProcessorFactoryImpl.java
+++ b/src/main/java/org/jvnet/hudson/maven/plugins/hpi/AnnotationProcessorFactoryImpl.java
@@ -21,6 +21,9 @@ import java.util.Set;
 
 /**
  * @author Kohsuke Kawaguchi
+ * @deprecated
+ *      As the annotation processing has switched to JSR-269,
+ *      we no longer need this code.
  */
 public class AnnotationProcessorFactoryImpl implements AnnotationProcessorFactory {
 

--- a/src/main/java/org/jvnet/hudson/maven/plugins/hpi/AptCompiler.java
+++ b/src/main/java/org/jvnet/hudson/maven/plugins/hpi/AptCompiler.java
@@ -16,6 +16,9 @@ import java.util.List;
  * In Maven, {@link Compiler} handles the actual compiler invocation.
  *
  * @author Kohsuke Kawaguchi
+ * @deprecated
+ *      As the annotation processing has switched to JSR-269,
+ *      we no longer need this code.
  */
 public class AptCompiler extends JavacCompiler {
 

--- a/src/main/java/org/jvnet/hudson/maven/plugins/hpi/AptMojo.java
+++ b/src/main/java/org/jvnet/hudson/maven/plugins/hpi/AptMojo.java
@@ -11,6 +11,9 @@ import java.lang.reflect.Field;
  * @phase compile
  * @requiresDependencyResolution compile
  * @author Kohsuke Kawaguchi
+ * @deprecated
+ *      As the annotation processing has switched to JSR-269,
+ *      we no longer need this code.
  */
 public class AptMojo extends CompilerMojo {
     public void execute() throws MojoExecutionException, CompilationFailureException {

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -11,7 +11,7 @@
             <id>default</id>
             <phases>
               <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
-              <compile>org.jvnet.hudson.tools:maven-hpi-plugin:apt-compile</compile>
+              <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
               <process-classes>org.kohsuke:access-modifier-checker:enforce</process-classes>
               <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
               <generate-test-sources>org.jvnet.hudson.tools:maven-hpi-plugin:insert-test</generate-test-sources>


### PR DESCRIPTION
Deprecating Sun APT API. Maven-stapler-plugin was upgraded to 1.16 (switching to JSR-269).
